### PR TITLE
Added a config variable that disables the mappings

### DIFF
--- a/doc/foldsearch.txt
+++ b/doc/foldsearch.txt
@@ -86,6 +86,8 @@ MAPPINGS                                                   *foldsearch-mappings*
 <Leader>fd     |:Fd|
 <Leader>fe     |:Fe|
 
+Mappings can be disabled by setting |g:foldsearch_disable_mappings| to 1
+
 ==============================================================================
 SETTINGS                                                   *foldsearch-settings*
 
@@ -102,6 +104,18 @@ Highlight the pattern used for folding.
 Value    Description~
 0        Don't highlight pattern.
 1        Highlight pattern.
+
+Default: 0
+
+------------------------------------------------------------------------------
+*g:foldsearch_disable_mappings*
+
+Disable the mappings. Use this to define your own mappings or to use the
+plugin via commands only.
+
+Value    Description~
+0        Don't disable mappings (use mappings)
+1        Disable Mappings
 
 Default: 0
 
@@ -122,6 +136,9 @@ CREDITS                                                     *foldsearch-credits*
 
 ==============================================================================
 CHANGELOG                                                 *foldsearch-changelog*
+
+v1.0.1 : 2013-03-20
+  - added |g:foldsearch_disable_mappings| config variable
 
 v1.0.0 : 2012-10-10
   - handle multiline regular expressions correctly

--- a/plugin/foldsearch.vim
+++ b/plugin/foldsearch.vim
@@ -34,6 +34,11 @@ if (!exists("g:foldsearch_highlight"))
   let g:foldsearch_highlight = 0
 endif
 
+" define default "foldsearch_disable_mappings" {{{2
+if (!exists("g:foldsearch_disable_mappings"))
+  let g:foldsearch_disable_mappings = 0
+endif
+
 " define default "foldsearch_debug" {{{2
 if (!exists("g:foldsearch_debug"))
   let g:foldsearch_debug = 0
@@ -407,13 +412,15 @@ command! -nargs=0 Fe call s:FoldSearchEnd()
 
 " Section: Mappings {{{1
 
-map <Leader>fs :call <SID>FoldSearch()<CR>
-map <Leader>fw :call <SID>FoldCword()<CR>
-map <Leader>fS :call <SID>FoldSpell()<CR>
-map <Leader>fl :call <SID>FoldLast()<CR>
-map <Leader>fi :call <SID>FoldContextAdd(+1)<CR>
-map <Leader>fd :call <SID>FoldContextAdd(-1)<CR>
-map <Leader>fe :call <SID>FoldSearchEnd()<CR>
+if !g:foldsearch_disable_mappings
+   map <Leader>fs :call <SID>FoldSearch()<CR>
+   map <Leader>fw :call <SID>FoldCword()<CR>
+   map <Leader>fS :call <SID>FoldSpell()<CR>
+   map <Leader>fl :call <SID>FoldLast()<CR>
+   map <Leader>fi :call <SID>FoldContextAdd(+1)<CR>
+   map <Leader>fd :call <SID>FoldContextAdd(-1)<CR>
+   map <Leader>fe :call <SID>FoldSearchEnd()<CR>
+endif
 
 " Section: Menu {{{1
 


### PR DESCRIPTION
This is a slick little plugin! I really like it.

However, I didn't care for the default mappings. I have &lt;leader&gt;f already set in my vimrc, and worse, in my muscle memory!

Anyway, this addition wont make any difference to current users, but if you set g:foldsearch_disable_mappings to 1 then the mappings aren't applied and you can use the plugin with your own mappings or via commands.

Thanks for the plugin!
