### PR TITLE
normal is normal!

### DIFF
--- a/plugin/foldsearch.vim
+++ b/plugin/foldsearch.vim
@@ -265,7 +265,7 @@ function! s:FoldSearchInit()
   let &foldminlines = 0
 
   " erase all folds to begin with
-  normal zE
+  normal! zE
 endfunction
 
 " Function: s:FoldSearchDo()  {{{2
@@ -295,7 +295,7 @@ function! s:FoldSearchDo()
   let cursor_position = line(".") . "normal!" . virtcol(".") . "|"
 
   " move to the end of the file
-  normal $G$
+  normal! $G$
   let pattern_found = 0      " flag to set when search pattern found
   let fold_created = 0       " flag to set when a fold is found
   let flags = "w"            " allow wrapping in the search
@@ -329,7 +329,7 @@ function! s:FoldSearchDo()
   endwhile
 
   " now create the last fold which goes to the end of the file.
-  normal $G
+  normal! $G
   let  line_fold_end = line(".")
   if (line_fold_end  >= line_fold_start && pattern_found == 1)
     execute ":". line_fold_start . "," . line_fold_end . "fold"
@@ -348,7 +348,7 @@ function! s:FoldSearchDo()
   execute cursor_position
 
   " make this position the vertical center
-  normal zz
+  normal! zz
 
 endfunction
 
@@ -383,13 +383,13 @@ function! s:FoldSearchEnd()
   echo "Foldsearch ended"
 
   " open all folds for the current cursor position
-  silent! execute "normal " . foldlevel(line(".")) . "zo"
+  silent! execute "normal! " . foldlevel(line(".")) . "zo"
 
   " restore position before folding
   execute cursor_position
 
   " make this position the vertical center
-  normal zz
+  normal! zz
 
 endfunction
 


### PR DESCRIPTION
Removed let &foldtext = "" to maintain custom foldtext in vimrc
normal is normal! to respect custom mappings. 
Error was caused by a custom `z` key mapping.
